### PR TITLE
fix script for non-FHS compliant distros

### DIFF
--- a/cfetch.sh
+++ b/cfetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # CFetch, made by melorin4 
 # https://github.com/melorin4/cfetch
 # Enjoy! :)


### PR DESCRIPTION
find `bash` on the user's `$PATH` instead of hardcoding to `/bin/bash`