### PR TITLE
improve kernel version field

### DIFF
--- a/cfetch.sh
+++ b/cfetch.sh
@@ -34,7 +34,7 @@ RAM_AVAIL=$((RAM_AVAIL_BYTES / 1024))
 RAM_USED=$((RAM_TOTAL - RAM_AVAIL))
 
 HOSTNAME=$(cat /etc/hostname)
-KERNEL=$(uname -r | head -c7)
+KERNEL=$(uname -r | cut -d"-" -f1)
 #
 #
 echo "${GREEN}╭╔═════════════════════════════════╗"╮


### PR DESCRIPTION
head -c7 is a fast approach, but there are some kernel versions out there having less than 7 characters.
Consider kernel version 5.11.0 
```
$ uname -r | head -c7
5.11.0-
```
I suggest using `cut`